### PR TITLE
Use regular sleep instead of deep sleep

### DIFF
--- a/source/sleep.c
+++ b/source/sleep.c
@@ -19,6 +19,17 @@
 #include "fsl_smc_hal.h"
 #include "objects.h"
 
+//  ______ _______   ____  __ ______   _   _   _
+// |  ____|_   _\ \ / /  \/  |  ____| | | | | | |
+// | |__    | |  \ V /| \  / | |__    | | | | | |
+// |  __|   | |   > < | |\/| |  __|   | | | | | |
+// | |     _| |_ / . \| |  | | |____  |_| |_| |_|
+// |_|    |_____/_/ \_\_|  |_|______| (_) (_) (_)
+//
+// Need to figure out the best sleep mode based on the peripherals
+// that actually need to be clocked rather than just going to the
+// least restrictive sleep mode
+
 void mbed_enter_sleep(sleep_t *obj)
 {
     (void)obj;


### PR DESCRIPTION
In the absence of a mechanism that would allow us to choose the best sleep
mode at runtime, we're forced to use the least restrictive one, otherwise
internal peripherals that might be in use will not work at all.
