### PR TITLE
Allow access of RTC to unprivileged mode

### DIFF
--- a/source/lp_ticker.c
+++ b/source/lp_ticker.c
@@ -89,10 +89,10 @@ void lp_ticker_init(void) {
     lp_ticker_inited = 1;
 
     // RTC might be configured already, don't reset it
+    RTC_HAL_SetSupervisorAccessCmd(RTC_BASE, true);
     if (!RTC_HAL_IsCounterEnabled(RTC_BASE)) {
         // select RTC for OSC32KSEL
-        SIM->SOPT1 &= ~SIM_SOPT1_OSC32KSEL_MASK;
-        SIM->SOPT1 |= SIM_SOPT1_OSC32KSEL(2);
+        CLOCK_HAL_SetSource(SIM_BASE, kClockOsc32kSel, 2);
         // configure RTC
         SIM_HAL_EnableRtcClock(SIM_BASE, 0U);
         RTC_HAL_Init(RTC_BASE);


### PR DESCRIPTION
The RTC module has a bit to allow unprivileged mode to access its registers;
this PR just sets it to one to make it work with uvisor.

Also, explicit writes to register `SIM->SOPT1` to select the 32KHz clock have been replaced
with the corresponding API call
