### PR TITLE
Uart: First clear then set the parity bits.

### DIFF
--- a/mbed-hal-ksdk-mcu/TARGET_KSDK_CODE/hal/uart/fsl_uart_hal.h
+++ b/mbed-hal-ksdk-mcu/TARGET_KSDK_CODE/hal/uart/fsl_uart_hal.h
@@ -402,6 +402,7 @@ static inline void UART_HAL_SetBitCountPerChar(uint32_t baseAddr,
  */
 static inline void UART_HAL_SetParityMode(uint32_t baseAddr, uart_parity_mode_t parityMode)
 {
+    HW_UART_C1_CLR(baseAddr, kUartParityOdd);
     HW_UART_C1_SET(baseAddr, parityMode);
 }
 


### PR DESCRIPTION
The code previously only ORed the new parityMode on top of the 
currently set mode in the register.
It was therefore impossible to return from Odd to Even Parity mode or even just switch parity off.

It is possible that there are some more of these errors in the KSDK.
This would not have been caught without our serial unit test, but we don't test for everything (like 9bit transfers + parity).

@0xc0170 @bogdanm @hugovincent 