### PR TITLE
Use uVisor API to access SCB->SCR

### DIFF
--- a/module.json
+++ b/module.json
@@ -63,11 +63,11 @@
     "mbed-hal-ksdk-mcu/TARGET_KSDK_CODE/utilities"
   ],
   "dependencies": {
+    "uvisor-lib": "~0.8.0",
     "mbed-hal": "*"
   },
   "targetDependencies": {
     "k64f": {
-      "uvisor-lib": "~0.8.0",
       "mbed-hal-k64f": "~0.4.0"
     }
   }

--- a/source/sleep.c
+++ b/source/sleep.c
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "uvisor-lib/uvisor-lib.h"
 #include "sleep_api.h"
 #include "cmsis.h"
 #include "fsl_mcg_hal.h"
@@ -44,7 +45,8 @@ void mbed_enter_sleep(sleep_t *obj)
     SMC_HAL_SetProtection(SMC_BASE, &sleep_config);
 
     //Regular sleep for ARM core:
-    SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
+    /* FIXME this will be replaced by a uVisor register-level gateway API */
+    uvisor_write32(&SCB->SCR, uvisor_read32(&(SCB->SCR)) & ~SCB_SCR_SLEEPDEEP_Msk);
     __WFI();
 }
 


### PR DESCRIPTION
`SCB->SCR` can only be accessed in privileged mode. This is a temporary measure and will be replaced with the relevant uVisor API for register-level access when it will be ready.

The dependency on `uvisor-lib` is now target-independent as `uvisor-lib` takes care of providing fallback implementation of all its APIs when a platform is not supported (protection is not enabled, in that case)

@0xc0170 @bogdanm 
@meriac 