### PR TITLE
Correct some rename warnings

### DIFF
--- a/mbed-hal-ksdk-mcu/gpio_object.h
+++ b/mbed-hal-ksdk-mcu/gpio_object.h
@@ -16,7 +16,7 @@
 #ifndef MBED_GPIO_OBJECT_H
 #define MBED_GPIO_OBJECT_H
 
-#include "mbed_assert.h"
+#include "mbed-drivers/mbed_assert.h"
 #include "fsl_gpio_hal.h"
 // #include "cmsis.h"
 

--- a/source/analogin_api.c
+++ b/source/analogin_api.c
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed_assert.h"
+#include "mbed-drivers/mbed_assert.h"
 #include "analogin_api.h"
 
 #if DEVICE_ANALOGIN

--- a/source/analogout_api.c
+++ b/source/analogout_api.c
@@ -18,8 +18,8 @@
 #if DEVICE_ANALOGOUT
 
 #include "cmsis.h"
-#include "pinmap.h"
-#include "mbed_error.h"
+#include "mbed-hal/pinmap.h"
+#include "mbed-drivers/mbed_error.h"
 #include "PeripheralPins.h"
 #include "fsl_clock_manager.h"
 

--- a/source/gpio_api.c
+++ b/source/gpio_api.c
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed_assert.h"
+#include "mbed-drivers/mbed_assert.h"
 #include "gpio_api.h"
 #include "pinmap.h"
 #include "fsl_port_hal.h"

--- a/source/gpio_irq_api.c
+++ b/source/gpio_irq_api.c
@@ -20,10 +20,10 @@
 
 #if DEVICE_INTERRUPTIN
 
-#include "gpio_api.h"
+#include "mbed-hal/gpio_api.h"
 #include "fsl_gpio_hal.h"
 #include "fsl_port_hal.h"
-#include "mbed_error.h"
+#include "mbed-drivers/mbed_error.h"
 #include "uvisor-lib/uvisor-lib.h"
 
 #define CHANNEL_NUM    160

--- a/source/i2c_api.c
+++ b/source/i2c_api.c
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed_assert.h"
-#include "i2c_api.h"
+#include "mbed-drivers/mbed_assert.h"
+#include "mbed-hal/i2c_api.h"
 
 #if DEVICE_I2C
 
 #include "cmsis.h"
-#include "pinmap.h"
+#include "mbed-hal/pinmap.h"
 #include "fsl_clock_manager.h"
 #include "fsl_i2c_hal.h"
 #include "fsl_port_hal.h"

--- a/source/pinmap.c
+++ b/source/pinmap.c
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed_assert.h"
-#include "pinmap.h"
-#include "mbed_error.h"
+#include "mbed-drivers/mbed_assert.h"
+#include "mbed-hal/pinmap.h"
+#include "mbed-drivers/mbed_error.h"
 #include "fsl_clock_manager.h"
 #include "fsl_port_hal.h"
 

--- a/source/pwmout_api.c
+++ b/source/pwmout_api.c
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed_assert.h"
+#include "mbed-drivers/mbed_assert.h"
 #include "pwmout_api.h"
 
 #if DEVICE_PWMOUT

--- a/source/serial_api.c
+++ b/source/serial_api.c
@@ -19,7 +19,7 @@
 
 // math.h required for floating point operations for baud rate calculation
 #include <math.h>
-#include "mbed_assert.h"
+#include "mbed-drivers/mbed_assert.h"
 
 #include <string.h>
 

--- a/source/spi_api.c
+++ b/source/spi_api.c
@@ -15,15 +15,15 @@
  */
 #include <math.h>
 #include <stdio.h>
-#include "mbed_assert.h"
+#include "mbed-drivers/mbed_assert.h"
 
-#include "spi_api.h"
+#include "mbed-hal/spi_api.h"
 
 #if DEVICE_SPI
 
 #include "cmsis.h"
-#include "pinmap.h"
-#include "mbed_error.h"
+#include "mbed-hal/pinmap.h"
+#include "mbed-drivers/mbed_error.h"
 #include "fsl_clock_manager.h"
 #include "fsl_dspi_hal.h"
 #include "PeripheralPins.h"


### PR DESCRIPTION
Correct warnings caused by https://github.com/ARMmbed/mbed-drivers/pull/104