### PR TITLE
SPI - set delay between transfers to 1/2 clock cycle

### DIFF
--- a/source/spi_api.c
+++ b/source/spi_api.c
@@ -112,6 +112,7 @@ void spi_frequency(spi_t *obj, int hz) {
     uint32_t busClock;
     CLOCK_SYS_GetFreq(kBusClock, &busClock);
     DSPI_HAL_SetBaudRate(obj->spi.address, kDspiCtar0, (uint32_t)hz, busClock);
+    DSPI_HAL_CalculateDelay(obj->spi.address, kDspiCtar0, kDspiAfterTransfer, busClock, 1000000000/(2*hz));
 }
 
 static inline int spi_writeable(spi_t * obj) {


### PR DESCRIPTION
The delay between bytes is set to minimum - default values in CTAR registers. To illustrate, the default delay with default clock 1 MHz was around 60ns.

This patch changes a delay between transfers to 1/2 clock cycle.

@bogdanm @niklas-arm @bremoran 