### PR TITLE
Clear pending IRQ moved after ISR registration

### DIFF
--- a/source/lp_ticker.c
+++ b/source/lp_ticker.c
@@ -103,8 +103,8 @@ void lp_ticker_init(void) {
         RTC_HAL_SetAlarmReg(RTC_BASE, 0);
         RTC_HAL_EnableCounter(RTC_BASE, true);
     }
-    vIRQ_ClearPendingIRQ(RTC_IRQn);
     vIRQ_SetVector(RTC_IRQn, (uint32_t)rct_isr);
+    vIRQ_ClearPendingIRQ(RTC_IRQn);
     vIRQ_EnableIRQ(RTC_IRQn);
 
     // configure LPTMR


### PR DESCRIPTION
In uVisor interrupt ownership is registered when the
`vIRQ_SetVector(irqn, vector)`
function is called, so this should always happen before other states
(like pending/enable status flags) are changed.

This commit does not change functionality, since the pending flag
is now cleared after registration, but still before enablement of the IRQ.

@0xc0170 