### PR TITLE
Serial -  readable/writeable fifo check fix

### DIFF
--- a/source/serial_api.c
+++ b/source/serial_api.c
@@ -230,14 +230,11 @@ void serial_putc(serial_t *obj, int c) {
 int serial_readable(serial_t *obj) {
     if (UART_HAL_GetStatusFlag(obj->serial.address, kUartRxOverrun))
         UART_HAL_ClearStatusFlag(obj->serial.address, kUartRxOverrun);
-    return UART_HAL_IsRxDataRegFull(obj->serial.address);
+    return !UART_HAL_IsRxFifoEmpty(obj->serial.address);
 }
 
 int serial_writable(serial_t *obj) {
-    if (UART_HAL_GetStatusFlag(obj->serial.address, kUartRxOverrun))
-        UART_HAL_ClearStatusFlag(obj->serial.address, kUartRxOverrun);
-
-    return UART_HAL_IsTxDataRegEmpty(obj->serial.address);
+    return obj->serial.entry_count - UART_HAL_GetTxDatawordCountInFifo(obj->serial.address);
 }
 
 void serial_pinout_tx(PinName tx) {


### PR DESCRIPTION
Use fifo check, as it's enabled in the serial_init(). The functions are already used write/read async

```
// serial interrupt
+-----------------+---------------+------------------------------------+--------+--------------------+-------------+
| target          | platform_name | test                               | result | elapsed_time (sec) | copy_method |
+-----------------+---------------+------------------------------------+--------+--------------------+-------------+
| frdm-k64f-armcc | K64F          | mbed-drivers-test-serial_interrupt | OK     | 4.92               | shell       |
+-----------------+---------------+------------------------------------+--------+--------------------+-------------+

// test echo
+-----------------+---------------+------------------------+--------+--------------------+-------------+
| target          | platform_name | test                   | result | elapsed_time (sec) | copy_method |
+-----------------+---------------+------------------------+--------+--------------------+-------------+
| frdm-k64f-armcc | K64F          | mbed-drivers-test-echo | OK     | 5.29               | shell       |
+-----------------+---------------+------------------------+--------+--------------------+-------------+
```

Tested, should not cause any regression. I could not locate why rx overrun was in the writable(), thus removed

@bogdanm @terhei 