### PR TITLE
Updated dependency on latest uvisor-lib

### DIFF
--- a/module.json
+++ b/module.json
@@ -64,7 +64,7 @@
     "mbed-hal-ksdk-mcu/TARGET_KSDK_CODE/utilities"
   ],
   "dependencies": {
-    "uvisor-lib": "^1.0.0",
+    "uvisor-lib": ">=1.0.0,<3.0.0",
     "mbed-hal": "*"
   },
   "targetDependencies": {


### PR DESCRIPTION
uvisor-lib 2.0.0 was just released. This commit updates the dependency
on uvisor-lib to take into account this version.